### PR TITLE
Use DigitsKit instead of TwitterKit

### DIFF
--- a/PFUser+Digits.m
+++ b/PFUser+Digits.m
@@ -6,7 +6,7 @@
 //
 
 #import <Bolts/Bolts.h>
-#import <TwitterKit/TwitterKit.h>
+#import <DigitsKit/DigitsKit.h>
 #import "PFUser+Digits.h"
 
 static NSString *const kSessionKey = @"session";
@@ -121,7 +121,7 @@ static NSString *const kAuthorizationHeaderKey = @"authorizationHeader";
             return;
         }
         
-        TWTROAuthSigning *oauthSigning = [[TWTROAuthSigning alloc] initWithAuthConfig:[Twitter sharedInstance].authConfig
+        DGTOAuthSigning *oauthSigning = [[DGTOAuthSigning alloc] initWithAuthConfig:[Digits sharedInstance].authConfig
                                                                           authSession:session];
         
         NSDictionary *authHeaders = [oauthSigning OAuthEchoHeadersToVerifyCredentials];


### PR DESCRIPTION
The Twitter Staff announced that they split Digits out from the Twitter Kit (http://get.digits.com/blog/introducing-the-digits-kit).

We can now use the `DGTOAuthSigning` class instead of the `TWTROAuthSigning` (see this thread: https://twittercommunity.com/t/introducing-digits-kit/38082)
